### PR TITLE
Changed interceptors

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -9,6 +9,9 @@ import (
 // The HandlerFunction type is an adapter to allow the use of ordinary functions as route handlers.
 type HandlerFunction func(*RequestContext) error
 
+// HandlerErrorFunction type is the type used by error interceptors.
+type HandlerErrorFunction func(*RequestContext, error) error
+
 // ServeFileHandler replies to the request with the contents of the named file or directory.
 // For example:
 // p := New()

--- a/pi.go
+++ b/pi.go
@@ -53,7 +53,7 @@ func (p *Pi) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func wrapHandler(handler HandlerFunction, routeURL string, parentRoutes ...*Route) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		context := newRequestContext(w, r, routeURL)
-		errorInterceptors := func(err error) {
+		errorInterceptors := func(c *RequestContext, err error) {
 			errorsHandled := false
 			for _, parentRoute := range parentRoutes {
 				errorsHandled = errorsHandled || parentRoute.Interceptors.runErrorInterceptors(context, err)
@@ -72,12 +72,12 @@ func wrapHandler(handler HandlerFunction, routeURL string, parentRoutes ...*Rout
 		}
 		for _, parentRoute := range parentRoutes {
 			if err := parentRoute.Interceptors.runBeforeInterceptors(context); err != nil {
-				errorInterceptors(err)
+				errorInterceptors(context, err)
 				return
 			}
 		}
 		if err := handler(context); err != nil {
-			errorInterceptors(err)
+			errorInterceptors(context, err)
 			return
 		}
 		for _, parentRoute := range parentRoutes {

--- a/route.go
+++ b/route.go
@@ -22,73 +22,21 @@ func newRoute(RouteURL string, ChildRoutes ...*Route) *Route {
 	}
 }
 
-// interceptorHelper is an helper to add single funcs to the interceptor list.
-type interceptorHelper struct {
-	BeforeFunc HandlerFunction
-	AfterFunc  HandlerFunction
-	ErrorFunc  func(error) HandlerFunction
-}
-
-func (helper *interceptorHelper) Before() HandlerFunction {
-	return helper.BeforeFunc
-}
-
-func (helper *interceptorHelper) After() HandlerFunction {
-	return helper.AfterFunc
-}
-
-func (helper *interceptorHelper) Error(err error) HandlerFunction {
-	return helper.ErrorFunc(err)
-}
-
 // Before registers an interceptor to be called before the request is handled.
-func (r *Route) Before(b beforeInterceptor) *Route {
-	r.Interceptors.addBefore(b)
-	return r
-}
-
-// BeforeFunc add an an Before handler to the interceptor.
-func (r *Route) BeforeFunc(handler HandlerFunction) *Route {
-	helper := &interceptorHelper{
-		BeforeFunc: handler,
-	}
-	r.Interceptors.addBefore(helper)
+func (r *Route) Before(handler HandlerFunction) *Route {
+	r.Interceptors.addBefore(handler)
 	return r
 }
 
 // After registers an interceptor to be called after the request has been handled.
-func (r *Route) After(a afterInterceptor) *Route {
-	r.Interceptors.addAfter(a)
-	return r
-}
-
-// AfterFunc add an an After interceptor.
-func (r *Route) AfterFunc(handler HandlerFunction) *Route {
-	helper := &interceptorHelper{
-		AfterFunc: handler,
-	}
-	r.Interceptors.addAfter(helper)
+func (r *Route) After(handler HandlerFunction) *Route {
+	r.Interceptors.addAfter(handler)
 	return r
 }
 
 // Error registers an interceptor to be called when an error occurs in the request handler or in any Before interceptor.
-func (r *Route) Error(e errorInterceptor) *Route {
-	r.Interceptors.addError(e)
-	return r
-}
-
-// ErrorFunc add an an Error interceptor.
-func (r *Route) ErrorFunc(handler func (error) HandlerFunction) *Route {
-	helper := &interceptorHelper{
-		ErrorFunc: handler,
-	}
-	r.Interceptors.addError(helper)
-	return r
-}
-
-// Intercept registers an interceptor to be called before, after or on error.
-func (r *Route) Intercept(ci interface{}) *Route {
-	r.Interceptors.addInterceptor(ci)
+func (r *Route) Error(handler HandlerErrorFunction) *Route {
+	r.Interceptors.addError(handler)
 	return r
 }
 


### PR DESCRIPTION
Now After and Before only needs an HandlerFunction, but I changed how the Error interceptors work.
They are now HandlerErrorFunction which takes the RequestContext and the error throw by whatever handler.

Also, when we catch the error, the After interceptors are not called, do we still use this pattern or we call them even though an error was raised?
